### PR TITLE
Fix bug decoding IMBs with data set to 0

### DIFF
--- a/intelligent_mail_barcode.py
+++ b/intelligent_mail_barcode.py
@@ -252,7 +252,7 @@ def decode (codes):
         if bump:
             val += 1287
         r.append (val)
-    if r[0] > 659:
+    if r[0] >= 659:
         fcs |= 1<<10
         r[0] -= 659
     r[9] >>= 1


### PR DESCRIPTION
If mailer ID, barcode ID, and serial number are all 0, decoding fails. This is because the code word is 0 when encoded, which gets 659 added to it, making it exactly 659. Changing line 255 to >= fixes this.
